### PR TITLE
Update Development File Watcher To Work With Docker

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -57,5 +57,5 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 end


### PR DESCRIPTION
The default file watcher does not work with Docker. To reflect changes, the container needs to be restarted. Using the `FileUpdateChecker` works properly.