### PR TITLE
Replace New Session Game Selector With Searchable Dropdown

### DIFF
--- a/app/assets/javascripts/sessions_new_form.js
+++ b/app/assets/javascripts/sessions_new_form.js
@@ -1,0 +1,20 @@
+$(document).ready(function() {
+
+    var data = {};
+    $("#games option").each(function(i,el) {  
+       data[$(el).data("value")] = $(el).val();
+    });
+    
+    $("#selectedGame").on('input', function () {
+        var inputGameName = this.value;
+        var selectedGame = $('#games').find('option').filter(function(){
+            return this.value == inputGameName;
+        });
+
+        if (selectedGame.length > 0) {
+            var gameId = $(selectedGame[0]).data('value');
+            console.log(gameId);
+            $('#session_game_id').val(gameId);    
+        }
+    });
+});

--- a/app/views/sessions/_form.html.erb
+++ b/app/views/sessions/_form.html.erb
@@ -31,14 +31,20 @@
  
   <div>
     <%= link_to_add_association 'add player', form, :session_players, 
-        data: { association_insertion_method: :append, association_insertion_node: '#players'} %>
+      data: { association_insertion_method: :append, association_insertion_node: '#players'} %>
   </div>
   <br/>
   <br/>
 
   <div>
     <%= form.label :game_id %>
-    <%= form.collection_select :game_id, Game.order(:name), :id, :name, include_blank: true %>
+    <%= form.hidden_field :game_id %>
+    <input id="selectedGame" list="games" />
+    <datalist id="games">
+      <% Game.order(:name).each do |game| %>
+        <option data-value="<%= game.id%>" value="<%= game.name %>"></option>
+      <% end %>
+    </datalist>
   </div>
 
   <div>


### PR DESCRIPTION
Previously the dropdown was a single massive game search. This is cumbersome with 200+ games in production. Replace with a searchable dropdown.

Created using jquery to only show the game names and using an input change event to set the hidden input that tracks/submits the game id.