### PR TITLE
Allow Session Edits

### DIFF
--- a/app/assets/javascripts/sessions_new_form.js
+++ b/app/assets/javascripts/sessions_new_form.js
@@ -1,12 +1,16 @@
-$(document).ready(function() {
-
+$(document).on('turbolinks:load', function() {
+    
+    //Make the dropdown properly selectable
     var data = {};
     $("#games option").each(function(i,el) {  
        data[$(el).data("value")] = $(el).val();
     });
-    
+
     $("#selectedGame").on('input', function () {
-        var inputGameName = this.value;
+        setHiddenGameIdValue(this.value);
+    });
+
+    function setHiddenGameIdValue(inputGameName) {
         var selectedGame = $('#games').find('option').filter(function(){
             return this.value == inputGameName;
         });
@@ -16,5 +20,5 @@ $(document).ready(function() {
             console.log(gameId);
             $('#session_game_id').val(gameId);    
         }
-    });
+    }
 });

--- a/app/views/sessions/_form.html.erb
+++ b/app/views/sessions/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: session, local: true) do |form| %>
+<%= form_with(model: session, local: true) do |f| %>
   <% if session.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(session.errors.count, "error") %> prohibited this session from being saved:</h2>
@@ -23,22 +23,22 @@
         </tr>
       </thead>
       <tbody id='players'>
-        <%= form.fields_for :session_players do |session_player| %>
-          <%= render 'session_player_fields', :form => session_player %>
+        <%= f.fields_for :session_players do |session_player| %>
+          <%= render 'session_player_fields', :f => session_player %>
         <% end %>
       </tbody>
     </table>
  
   <div>
-    <%= link_to_add_association 'add player', form, :session_players, 
+    <%= link_to_add_association 'add player', f, :session_players, 
       data: { association_insertion_method: :append, association_insertion_node: '#players'} %>
   </div>
   <br/>
   <br/>
 
   <div>
-    <%= form.label :game_id %>
-    <%= form.hidden_field :game_id %>
+    <%= f.label :game_id %>
+    <%= f.hidden_field :game_id %>
     <input id="selectedGame" list="games" />
     <datalist id="games">
       <% Game.order(:name).each do |game| %>
@@ -48,17 +48,17 @@
   </div>
 
   <div>
-    <%= form.label :played %>
-    <%= form.date_field :played, as: :date %>
+    <%= f.label :played %>
+    <%= f.date_field :played, as: :date %>
   </div>
 
   <div>
-    <%= form.label :notes %>
-    <%= form.text_field :notes %>
+    <%= f.label :notes %>
+    <%= f.text_field :notes %>
   </div>
 
   <div class="actions">
-    <%= form.submit %>
+    <%= f.submit %>
   </div>
 <% end %>
 

--- a/app/views/sessions/_form.html.erb
+++ b/app/views/sessions/_form.html.erb
@@ -39,7 +39,7 @@
   <div>
     <%= f.label :game_id %>
     <%= f.hidden_field :game_id %>
-    <input id="selectedGame" list="games" />
+    <input id="selectedGame" list="games" value="<%= session&.game&.name %>" />
     <datalist id="games">
       <% Game.order(:name).each do |game| %>
         <option data-value="<%= game.id%>" value="<%= game.name %>"></option>


### PR DESCRIPTION
The edit page was broken with the change to a nested form for the players. This was fixed by changing the form variable name due to an apparent issue with cocoon expecting it to be `f`.

Also, updated the selected game to reflect the current option when editing an existing session.