### PR TITLE
Proper Numeric Inputs

### DIFF
--- a/app/views/games/_form.html.erb
+++ b/app/views/games/_form.html.erb
@@ -18,7 +18,7 @@
 
   <div class="field">
     <%= form.label :bgg_id %>
-    <%= form.text_field :bgg_id %>
+    <%= form.number_field :bgg_id %>
   </div>
 
   <div class="field">

--- a/app/views/sessions/_session_player_fields.html.erb
+++ b/app/views/sessions/_session_player_fields.html.erb
@@ -1,7 +1,7 @@
 <tr class='nested-fields row'>
     <td class='field'><%= f.collection_select :player_id, Player.order(:name), :id, :name, include_blank: true %></td> 
-    <td class='field'><%= f.text_field :score %></td>
-    <td class='field'><%= f.text_field :placing %></td>
+    <td class='field'><%= f.number_field :score %></td>
+    <td class='field'><%= f.number_field :placing %></td>
     <td class='field'><%= f.text_field :team %></td>
     <td>
         <%= link_to_remove_association 'remove', f %>


### PR DESCRIPTION
The inputs for the following fields allowed full text. Changed to numerics-only to better handle mobile input.

* New session player **placing**
* New session player **score**
* New game **bgg id**

*Note* That placing can be a decimal (usually half) in some games, which is still allowed in numeric inputs.