### PR TITLE
Update Show/View Pages To Be Responsive

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,3 +12,8 @@
  *
  */
 @import "bootstrap";
+
+.caption-top-bold {
+    caption-side: top;
+    font-weight: bold;
+}

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -24,7 +24,7 @@
   <div class="row">
     <div class="col-md-4">
       <table class="table table-bordered">
-        <caption style="caption-side: top; font-weight: bold;">Best Player</caption>
+        <caption class="caption-top-bold">Best Player</caption>
         <thead>
           <tr>
             <th>Name</th>
@@ -47,7 +47,7 @@
   <div class="row">
     <div class="col-md-4">
       <table class="table table-bordered">
-        <caption style="caption-side: top; font-weight: bold;">Worst Player</caption>
+        <caption class="caption-top-bold">Worst Player</caption>
         <thead>
           <tr>
             <th>Name</th>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,61 +1,70 @@
-<p>
-  <strong>Name:</strong>
+<h1 class="text-center">
   <%= @game.name %>
-</p>
+</h1>
 
-<p>
-  <strong>Bgg Id:</strong>
-  <%= @game.bgg_id %>
-</p>
-
-<p>
-  <strong>Game Type:</strong>
-  <%= @game.game_type.capitalize %>
-</p>
+<div class="container">
+  <div class="row">
+    <div class="col-md-6 font-weight-bold">
+      Bgg Id:
+    </div>
+    <div class="col-md-6">
+      <%= @game.bgg_id %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-6 font-weight-bold">
+      Game Type:
+    </div>
+    <div class="col-md-6">
+      <%= @game.game_type.capitalize %>
+    </div>
+  </div>
 
 <% unless @game.best_player.nil? %>
-  <p>
-    <strong>Best Player:</strong>
-  </p>
-
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Win %</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><%= link_to @game.best_player.player.name, @game.best_player.player %></td>
-        <td><%= @game.best_player.win_percent.round(4) * 100 %></td>
-      </tr>
-    </tbody>
-  </table>
+  <div class="row">
+    <div class="col-md-4">
+      <table class="table table-bordered">
+        <caption style="caption-side: top; font-weight: bold;">Best Player</caption>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Win %</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><%= link_to @game.best_player.player.name, @game.best_player.player %></td>
+            <td><%= @game.best_player.win_percent.round(4) * 100 %></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
 
 <% end %>
 
 <% unless @game.worst_player.nil? %>
-  <p>
-    <strong>Worst Player:</strong>
-  </p>
-
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Win %</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><%= link_to @game.worst_player.player.name, @game.worst_player.player %></td>
-        <td><%= @game.worst_player.win_percent.round(4) * 100 %></td>
-      </tr>
-    </tbody>
-  </table>
+  <div class="row">
+    <div class="col-md-4">
+      <table class="table table-bordered">
+        <caption style="caption-side: top; font-weight: bold;">Worst Player</caption>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Win %</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><%= link_to @game.worst_player.player.name, @game.worst_player.player %></td>
+            <td><%= @game.worst_player.win_percent.round(4) * 100 %></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
 <% end %>
-
+</div>
 
 <%= link_to 'Edit', edit_game_path(@game) %> |
 <%= link_to 'Back', games_path %>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -34,7 +34,7 @@
         <tbody>
           <tr>
             <td><%= link_to @game.best_player.player.name, @game.best_player.player %></td>
-            <td><%= @game.best_player.win_percent.round(4) * 100 %></td>
+            <td><%= number_with_precision((@game.best_player.win_percent * 100), precision: 2, strip_insignificant_zeros: true) %></td>
           </tr>
         </tbody>
       </table>
@@ -57,7 +57,7 @@
         <tbody>
           <tr>
             <td><%= link_to @game.worst_player.player.name, @game.worst_player.player %></td>
-            <td><%= @game.worst_player.win_percent.round(4) * 100 %></td>
+            <td><%= number_with_precision((@game.worst_player.win_percent * 100), precision: 2, strip_insignificant_zeros: true) %></td>
           </tr>
         </tbody>
       </table>

--- a/app/views/players/show.html.erb
+++ b/app/views/players/show.html.erb
@@ -9,7 +9,7 @@
       Overall Win Rate
     </div>
     <div class="col-md">
-      <%= (@player.win_rate * 100).round(2) %>%
+      <td><%= number_with_precision((@player.win_rate * 100), precision: 2, strip_insignificant_zeros: true) %></td>%
     </div>
   </div>
 
@@ -28,7 +28,7 @@
         <tbody>
           <tr>
             <td><%= link_to @player.best_game.game.name, @player.best_game.game %></td>
-            <td><%= (@player.best_game.win_percent * 100).round(2) %></td>
+            <td><%= number_with_precision((@player.best_game.win_percent * 100), precision: 2, strip_insignificant_zeros: true) %></td>
           </tr>
         </tbody>
       </table>
@@ -52,7 +52,7 @@
         <tbody>
           <tr>
             <td><%= link_to @player.worst_game.game.name, @player.worst_game.game %></td>
-            <td><%= (@player.worst_game.win_percent * 100).round(2) %></td>
+            <td><%= number_with_precision((@player.worst_game.win_percent * 100), precision: 2, strip_insignificant_zeros: true) %></td>
           </tr>
         </tbody>
       </table>

--- a/app/views/players/show.html.erb
+++ b/app/views/players/show.html.erb
@@ -18,7 +18,7 @@
   <div class="row">
     <div class="col-md-4">
       <table class="table table-bordered">
-        <caption style="caption-side: top; font-weight: bold;">Best Game</caption>
+        <caption class="caption-top-bold">Best Game</caption>
         <thead>
           <tr>
             <th>Name</th>
@@ -42,7 +42,7 @@
   <div class="row">
     <div class="col-md-4">
       <table class="table table-bordered">
-        <caption style="caption-side: top; font-weight: bold;">Worst Game</caption>
+        <caption class="caption-top-bold">Worst Game</caption>
         <thead>
           <tr>
             <th>Name</th>

--- a/app/views/players/show.html.erb
+++ b/app/views/players/show.html.erb
@@ -1,59 +1,66 @@
-<p>
-  <strong>Name:</strong>
+<h1 class="text-center">
   <%= @player.name %>
-</p>
+</h1>
 
-<p>
-  <strong>Overall Win Rate:</strong>
-  <%= @player.win_rate.round(4) * 100 %>%
-</p>
 
+<div class="container">
+  <div class="row">
+    <div class="col-md font-weight-bold">
+      Overall Win Rate
+    </div>
+    <div class="col-md">
+      <%= (@player.win_rate * 100).round(2) %>%
+    </div>
+  </div>
 
 <% unless @player.best_game.nil? %>
 
-<p>
-  <strong>Best Game:</strong>
-</p>
+  <div class="row">
+    <div class="col-md-4">
+      <table class="table table-bordered">
+        <caption style="caption-side: top; font-weight: bold;">Best Game</caption>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Win %</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><%= link_to @player.best_game.game.name, @player.best_game.game %></td>
+            <td><%= (@player.best_game.win_percent * 100).round(2) %></td>
+          </tr>
+        </tbody>
+      </table>
 
-<table>
-  <thead>
-    <tr>
-      <th>Name</th>
-      <th>Win %</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><%= link_to @player.best_game.game.name, @player.best_game.game %></td>
-      <td><%= @player.best_game.win_percent.round(4) * 100 %></td>
-    </tr>
-  </tbody>
-</table>
+    </div>
+  </div>
 
 <% end %>
 
 <% unless @player.worst_game.nil? %>
-
-<p>
-  <strong>Worst Game:</strong>
-</p>
-
-<table>
-  <thead>
-    <tr>
-      <th>Name</th>
-      <th>Win %</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><%= link_to @player.worst_game.game.name, @player.worst_game.game %></td>
-      <td><%= @player.worst_game.win_percent.round(4) * 100 %></td>
-    </tr>
-  </tbody>
-</table>
-
+  <div class="row">
+    <div class="col-md-4">
+      <table class="table table-bordered">
+        <caption style="caption-side: top; font-weight: bold;">Worst Game</caption>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Win %</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><%= link_to @player.worst_game.game.name, @player.worst_game.game %></td>
+            <td><%= (@player.worst_game.win_percent * 100).round(2) %></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
 <% end %>
+
+</div>
 
 <%= link_to 'Edit', edit_player_path(@player) %> |
 <%= link_to 'Back', players_path %>

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -1,39 +1,53 @@
-<p>
-  <strong>Game:</strong>
-  <%= link_to @session.game.name, @session.game %>
-</p>
-
-<p>
-  <strong>Played:</strong>
-  <%= @session.played %>
-</p>
-
-<p>
-  <strong>Notes:</strong>
-  <%= @session.notes %>
-</p>
-
-<h3>Players:</h3>
-<table>
-<thead>
-    <tr>
-        <th>Player</th>
-        <th>Score</th>
-        <th>Placing</th>
-        <th>Team</th>
-    </tr>
-</thead>
-<tbody>
-    <% @session.session_players.order(:placing).each do |player| %>
-      <tr>
-        <td><%= link_to player.player.name, player.player %></td>
-        <td><%= player.score %></td>
-        <td><%= player.placing %></td>
-        <td><%= player.team %></td>
-    <% end %>
-</tbody>
-</table>
- <br/>
+<div class="container">
+  <div class="row">
+    <div class="col-md font-weight-bold">
+      Game:
+    </div>
+    <div class="col-md">
+      <%= link_to @session.game.name, @session.game %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md font-weight-bold">
+      Played
+    </div>
+    <div class="col-md">
+      <%= @session.played %>      
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md font-weight-bold">
+      Notes
+    </div>
+    <div class="col-md">
+      <%= @session.notes %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md">
+      <table class="table table-striped table-bordered">
+      <caption class="caption-top-bold">Players</caption>
+      <thead>
+          <tr>
+              <th>Player</th>
+              <th>Score</th>
+              <th>Placing</th>
+              <th>Team</th>
+          </tr>
+      </thead>
+      <tbody>
+          <% @session.session_players.order(:placing).each do |player| %>
+            <tr>
+              <td><%= link_to player.player.name, player.player %></td>
+              <td><%= number_with_precision(player.score, strip_insignificant_zeros: true) %></td>
+              <td><%= player.placing %></td>
+              <td><%= player.team %></td>
+          <% end %>
+      </tbody>
+      </table>
+    </div>
+  </div>
+</div>
 
 <%= link_to 'Edit', edit_session_path(@session) %> |
 <%= link_to 'Back', sessions_path %>


### PR DESCRIPTION
Use bootstrap to make the Show/View pages responsive by moving all data into a grid and making the tables responsive bootstrap tables.

Additionally, small change to make all percentage displays on pages use `number_with_precision` built-in rails function instead of manually handling rounding. This also gives the benefit of hiding the insignificant zeroes (eg converting `60.00%` to `60%).