### PR TITLE
Display Top 3 Placings For Game And Players

### DIFF
--- a/app/models/concerns/games/player_stats.rb
+++ b/app/models/concerns/games/player_stats.rb
@@ -8,23 +8,13 @@ module Games
         return game_totals.take(RESULT_COUNT).map{|game_total| to_stats(game_total)}
       end
 
-      def worst_player
-        stats = to_stats(game_totals.last)
-
-        # if (!best_players.nil? && !stats.nil? && best_player.win_percent == stats.win_percent)
-        #   return nil
-        # else
-          return stats
-        # end
-      end
-
       private
         def game_totals
           # Have to declare win_percentage because (wins / plays) doesn't work in ordering
           # In win_percentage calculation, have to cast one operand to float to ensure float result
           Session.joins(:session_players)
               .select('session_players.player_id,
-                 count(*) as plays,
+                 count(*) as count,
                  sum(case "placing"
                     when 1 then 1
                     else 0 end) as wins,
@@ -32,7 +22,7 @@ module Games
               .where('game_id = ?', id)
               .where('session_players.player_id > 0')
               .group('session_players.player_id')
-              .order('win_percentage desc')
+              .order('win_percentage desc, count desc')
         end
 
         def to_stats (game_total)
@@ -40,6 +30,7 @@ module Games
           player_stats = PlayerWinPercent.new
           player_stats.win_percent = game_total.win_percentage
           player_stats.player = Player.find(game_total.player_id)
+          player_stats.play_count = game_total.count
           return player_stats
         end
     end

--- a/app/models/concerns/games/player_stats.rb
+++ b/app/models/concerns/games/player_stats.rb
@@ -1,19 +1,21 @@
 module Games
     module PlayerStats
         extend ActiveSupport::Concern
+      
+      RESULT_COUNT = 3
 
-      def best_player
-        return to_stats(game_totals.first)
+      def best_players
+        return game_totals.take(RESULT_COUNT).map{|game_total| to_stats(game_total)}
       end
 
       def worst_player
         stats = to_stats(game_totals.last)
 
-        if (!best_player.nil? && !stats.nil? && best_player.win_percent == stats.win_percent)
-          return nil
-        else
+        # if (!best_players.nil? && !stats.nil? && best_player.win_percent == stats.win_percent)
+        #   return nil
+        # else
           return stats
-        end
+        # end
       end
 
       private

--- a/app/models/concerns/players/game_stats.rb
+++ b/app/models/concerns/players/game_stats.rb
@@ -14,9 +14,8 @@ module Players
                         .group('game_id')
                         .select('game_id,
                             sum(subquery.didWin) / count(*)::float as win_percentage,
-                            count(*) as count,
-                            sum(subquery.didWin) as win_count')
-                        .order('win_percentage desc')
+                            count(*) as count')
+                        .order('win_percentage desc, count desc')
                         .take(RESULT_COUNT)
 
             return query_result.map{|game_total| to_percent(game_total)}
@@ -33,7 +32,8 @@ module Players
             query_result = Game.from(subquery)
                                .group('game_id')
                                .select('game_id,
-                             sum(subquery.didWin) / count(*)::float as win_percentage')
+                             sum(subquery.didWin) / count(*)::float as win_percentage,
+                             count(*) as count')
                                .order('win_percentage asc')
                                .take(RESULT_COUNT)
     
@@ -60,6 +60,7 @@ module Players
                 game_stats = GameWinPercent.new
                 game_stats.win_percent = game_total.win_percentage
                 game_stats.game = Game.find(game_total.game_id)
+                game_stats.play_count = game_total.count
                 return game_stats
             end
     end

--- a/app/models/concerns/players/game_stats.rb
+++ b/app/models/concerns/players/game_stats.rb
@@ -2,6 +2,7 @@ module Players
     module GameStats
         extend ActiveSupport::Concern
         RESULT_COUNT = 3
+        
         def best_games
             subquery = SessionPlayer.joins(:session)
                        .group('sessions.id, sessions.game_id')
@@ -34,7 +35,7 @@ module Players
                                .select('game_id,
                              sum(subquery.didWin) / count(*)::float as win_percentage,
                              count(*) as count')
-                               .order('win_percentage asc')
+                               .order('win_percentage asc, count desc')
                                .take(RESULT_COUNT)
     
             return query_result.map{|game_total| to_percent(game_total)}

--- a/app/models/concerns/players/game_stats.rb
+++ b/app/models/concerns/players/game_stats.rb
@@ -22,7 +22,7 @@ module Players
             return query_result.map{|game_total| to_percent(game_total)}
         end
 
-        def worst_game
+        def worst_games
             subquery = SessionPlayer.joins(:session)
                            .group('sessions.id, sessions.game_id')
                            .where('player_id = ?', id)
@@ -35,9 +35,9 @@ module Players
                                .select('game_id,
                              sum(subquery.didWin) / count(*)::float as win_percentage')
                                .order('win_percentage asc')
-                               .first
+                               .take(RESULT_COUNT)
     
-            return to_percent(query_result)
+            return query_result.map{|game_total| to_percent(game_total)}
         end
 
         def win_rate

--- a/app/models/concerns/players/game_stats.rb
+++ b/app/models/concerns/players/game_stats.rb
@@ -1,8 +1,8 @@
 module Players
     module GameStats
         extend ActiveSupport::Concern
-
-        def best_game
+        RESULT_COUNT = 3
+        def best_games
             subquery = SessionPlayer.joins(:session)
                        .group('sessions.id, sessions.game_id')
                        .where('player_id = ?', id)
@@ -17,9 +17,9 @@ module Players
                             count(*) as count,
                             sum(subquery.didWin) as win_count')
                         .order('win_percentage desc')
-                        .first
+                        .take(RESULT_COUNT)
 
-            return to_percent(query_result)
+            return query_result.map{|game_total| to_percent(game_total)}
         end
 
         def worst_game

--- a/app/models/game_win_percent.rb
+++ b/app/models/game_win_percent.rb
@@ -1,3 +1,3 @@
 class GameWinPercent
-    attr_accessor :game, :win_percent
+    attr_accessor :game, :win_percent, :play_count
 end

--- a/app/models/player_win_percent.rb
+++ b/app/models/player_win_percent.rb
@@ -1,3 +1,3 @@
 class PlayerWinPercent
-  attr_accessor :player, :win_percent
+  attr_accessor :player, :win_percent, :play_count
 end

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -20,52 +20,32 @@
     </div>
   </div>
 
-<% unless @game.best_players.nil? %>
-  <div class="row">
-    <div class="col-md-4">
-      <table class="table table-bordered">
-        <caption class="caption-top-bold">Best Players</caption>
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Win %</th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @game.best_players.each do |best_player| %>
+  <% unless @game.best_players.nil? %>
+    <div class="row">
+      <div class="col-md-4">
+        <table class="table table-bordered">
+          <caption class="caption-top-bold">Best Players</caption>
+          <thead>
             <tr>
-              <td><%= link_to best_player.player.name, best_player.player %></td>
-              <td><%= number_with_precision((best_player.win_percent * 100), precision: 2, strip_insignificant_zeros: true) %></td>
+              <th>Name</th>
+              <th>Win %</th>
+              <th>Play Count</th>
             </tr>
-          <% end %>
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            <% @game.best_players.each do |best_player| %>
+              <tr>
+                <td><%= link_to best_player.player.name, best_player.player %></td>
+                <td><%= number_with_precision((best_player.win_percent * 100), precision: 2, strip_insignificant_zeros: true) %></td>
+                <td><%= best_player.play_count %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
     </div>
-  </div>
 
-<% end %>
-
-<% unless @game.worst_player.nil? %>
-  <div class="row">
-    <div class="col-md-4">
-      <table class="table table-bordered">
-        <caption class="caption-top-bold">Worst Player</caption>
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Win %</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><%= link_to @game.worst_player.player.name, @game.worst_player.player %></td>
-            <td><%= number_with_precision((@game.worst_player.win_percent * 100), precision: 2, strip_insignificant_zeros: true) %></td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  </div>
-<% end %>
+  <% end %>
 </div>
 
 <%= link_to 'Edit', edit_game_path(@game) %> |

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -20,11 +20,11 @@
     </div>
   </div>
 
-<% unless @game.best_player.nil? %>
+<% unless @game.best_players.nil? %>
   <div class="row">
     <div class="col-md-4">
       <table class="table table-bordered">
-        <caption class="caption-top-bold">Best Player</caption>
+        <caption class="caption-top-bold">Best Players</caption>
         <thead>
           <tr>
             <th>Name</th>
@@ -32,10 +32,12 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td><%= link_to @game.best_player.player.name, @game.best_player.player %></td>
-            <td><%= number_with_precision((@game.best_player.win_percent * 100), precision: 2, strip_insignificant_zeros: true) %></td>
-          </tr>
+          <% @game.best_players.each do |best_player| %>
+            <tr>
+              <td><%= link_to best_player.player.name, best_player.player %></td>
+              <td><%= number_with_precision((best_player.win_percent * 100), precision: 2, strip_insignificant_zeros: true) %></td>
+            </tr>
+          <% end %>
         </tbody>
       </table>
     </div>

--- a/app/views/players/show.html.erb
+++ b/app/views/players/show.html.erb
@@ -23,6 +23,7 @@
           <tr>
             <th>Name</th>
             <th>Win %</th>
+            <th>Play Count</th>
           </tr>
         </thead>
         <tbody>
@@ -30,6 +31,7 @@
             <tr>
               <td><%= link_to best_game.game.name, best_game.game %></td>
               <td><%= number_with_precision((best_game.win_percent * 100), precision: 2, strip_insignificant_zeros: true) %></td>
+              <td><%= best_game.play_count %></td>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/players/show.html.erb
+++ b/app/views/players/show.html.erb
@@ -40,11 +40,11 @@
 
 <% end %>
 
-<% unless @player.worst_game.nil? %>
+<% unless @player.worst_games.nil? %>
   <div class="row">
     <div class="col-md-4">
       <table class="table table-bordered">
-        <caption class="caption-top-bold">Worst Game</caption>
+        <caption class="caption-top-bold">Worst Games</caption>
         <thead>
           <tr>
             <th>Name</th>
@@ -52,10 +52,12 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td><%= link_to @player.worst_game.game.name, @player.worst_game.game %></td>
-            <td><%= number_with_precision((@player.worst_game.win_percent * 100), precision: 2, strip_insignificant_zeros: true) %></td>
-          </tr>
+          <% @player.worst_games.each do |worst_game| %>
+            <tr>
+              <td><%= link_to worst_game.game.name, worst_game.game %></td>
+              <td><%= number_with_precision((worst_game.win_percent * 100), precision: 2, strip_insignificant_zeros: true) %></td>
+            </tr>
+          <% end %>
         </tbody>
       </table>
     </div>

--- a/app/views/players/show.html.erb
+++ b/app/views/players/show.html.erb
@@ -13,12 +13,12 @@
     </div>
   </div>
 
-<% unless @player.best_game.nil? %>
+<% unless @player.best_games.nil? %>
 
   <div class="row">
     <div class="col-md-4">
       <table class="table table-bordered">
-        <caption class="caption-top-bold">Best Game</caption>
+        <caption class="caption-top-bold">Best Games</caption>
         <thead>
           <tr>
             <th>Name</th>
@@ -26,10 +26,12 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td><%= link_to @player.best_game.game.name, @player.best_game.game %></td>
-            <td><%= number_with_precision((@player.best_game.win_percent * 100), precision: 2, strip_insignificant_zeros: true) %></td>
-          </tr>
+          <% @player.best_games.each do |best_game| %>
+            <tr>
+              <td><%= link_to best_game.game.name, best_game.game %></td>
+              <td><%= number_with_precision((best_game.win_percent * 100), precision: 2, strip_insignificant_zeros: true) %></td>
+            </tr>
+          <% end %>
         </tbody>
       </table>
 

--- a/app/views/players/show.html.erb
+++ b/app/views/players/show.html.erb
@@ -51,6 +51,7 @@
           <tr>
             <th>Name</th>
             <th>Win %</th>
+            <th>Play Count</th>
           </tr>
         </thead>
         <tbody>
@@ -58,6 +59,7 @@
             <tr>
               <td><%= link_to worst_game.game.name, worst_game.game %></td>
               <td><%= number_with_precision((worst_game.win_percent * 100), precision: 2, strip_insignificant_zeros: true) %></td>
+              <td><%= worst_game.play_count %></td>
             </tr>
           <% end %>
         </tbody>

--- a/test/models/concerns/games/player_stats_test.rb
+++ b/test/models/concerns/games/player_stats_test.rb
@@ -14,6 +14,7 @@ class PlayerStatsTest < ActiveSupport::TestCase
       best_player = best_players.first
       assert_includes [winning_player], best_player.player
       assert_equal 1, best_player.win_percent
+      assert_equal 1, best_player.play_count
     end
     
     test "should return a player as best player when tied for best" do
@@ -29,6 +30,7 @@ class PlayerStatsTest < ActiveSupport::TestCase
       best_player = best_players.first
       assert_includes [winning_player1, winning_player2], best_player.player
       assert_equal 1, best_player.win_percent
+      assert_equal 1, best_player.play_count
     end
 
     test "should ignore unknown player as best player" do
@@ -44,54 +46,23 @@ class PlayerStatsTest < ActiveSupport::TestCase
       best_player = best_players.first
       assert_equal known_player, best_player.player
       assert_equal 0.5, best_player.win_percent
+      assert_equal 2, best_player.play_count
     end
-
-    test "should return a player as worst player" do
+    
+    test "should choose most played game when tied for best game" do
       game = create_game
-      losing_player = create_player
-      winning_player = create_player
+      player_one = create_player
+      player_two = create_player('other')
+      create_session(game, winning_players: [player_one])
+      create_session(game, winning_players: [player_two])
+      create_session(game, winning_players: [player_two])
 
-      create_session(game, winning_players: [winning_player],
-                     losing_players: [losing_player])
+      best_players = game.best_players
 
-      assert_includes [losing_player], game.worst_player.player
-      assert_equal 0, game.worst_player.win_percent
-    end
-
-    test "should return a player as worst player when tied for best" do
-      game = create_game
-      winning_player = create_player
-      losing_player1 = create_player
-      losing_player2 = create_player
-
-      create_session(game, winning_players: [winning_player], 
-                    losing_players: [losing_player1, losing_player2])
-
-      assert_includes [losing_player1, losing_player2], game.worst_player.player
-      assert_equal 0, game.worst_player.win_percent
-    end
-
-    # test "should return nil as worst player when all players are tied for stats" do
-    #   game = create_game
-    #   player1 = create_player
-    #   player2 = create_player
-
-    #   create_session(game, winning_players: [player1])
-    #   create_session(game, winning_players: [player2])
-
-    #   assert_nil game.worst_player
-    # end
-
-    test "should ignore unknown player as worst player" do
-      game = create_game
-      known_player = create_player
-      best_player = create_player
-      unknown_player = players(:unknown)
-
-      create_session(game, losing_players: [unknown_player, known_player])
-      create_session(game, winning_players: [known_player, best_player])
-
-      assert_equal known_player, game.worst_player.player
-      assert_equal 0.5, game.worst_player.win_percent
-    end
+      assert_equal 2, best_players.count
+      best_player = best_players.first
+      assert_equal player_two, best_player.player
+      assert_equal 1, best_player.win_percent
+      assert_equal 2, best_player.play_count
+  end
 end

--- a/test/models/concerns/games/player_stats_test.rb
+++ b/test/models/concerns/games/player_stats_test.rb
@@ -6,35 +6,44 @@ class PlayerStatsTest < ActiveSupport::TestCase
     test "should return a player as best player" do
       game = create_game
       winning_player = create_player
-
       create_session(game, winning_players: [winning_player])
 
-      assert_includes [winning_player], game.best_player.player
-      assert_equal 1, game.best_player.win_percent
+      best_players = game.best_players
+
+      assert_equal 1, best_players.count
+      best_player = best_players.first
+      assert_includes [winning_player], best_player.player
+      assert_equal 1, best_player.win_percent
     end
     
     test "should return a player as best player when tied for best" do
       game = create_game
       winning_player1 = create_player
       winning_player2 = create_player
-
       create_session(game, winning_players: [winning_player1])
       create_session(game, winning_players: [winning_player2])
 
-      assert_includes [winning_player1, winning_player2], game.best_player.player
-      assert_equal 1, game.best_player.win_percent
+      best_players = game.best_players
+
+      assert_equal 2, best_players.count
+      best_player = best_players.first
+      assert_includes [winning_player1, winning_player2], best_player.player
+      assert_equal 1, best_player.win_percent
     end
 
     test "should ignore unknown player as best player" do
       game = create_game
       known_player = create_player
       unknown_player = players(:unknown)
-
       create_session(game, winning_players: [unknown_player, known_player])
       create_session(game, losing_players: [known_player])
 
-      assert_equal known_player, game.best_player.player
-      assert_equal 0.5, game.best_player.win_percent
+      best_players = game.best_players
+
+      assert_equal 1, best_players.count
+      best_player = best_players.first
+      assert_equal known_player, best_player.player
+      assert_equal 0.5, best_player.win_percent
     end
 
     test "should return a player as worst player" do
@@ -62,16 +71,16 @@ class PlayerStatsTest < ActiveSupport::TestCase
       assert_equal 0, game.worst_player.win_percent
     end
 
-    test "should return nil as worst player when all players are tied for stats" do
-      game = create_game
-      player1 = create_player
-      player2 = create_player
+    # test "should return nil as worst player when all players are tied for stats" do
+    #   game = create_game
+    #   player1 = create_player
+    #   player2 = create_player
 
-      create_session(game, winning_players: [player1])
-      create_session(game, winning_players: [player2])
+    #   create_session(game, winning_players: [player1])
+    #   create_session(game, winning_players: [player2])
 
-      assert_nil game.worst_player
-    end
+    #   assert_nil game.worst_player
+    # end
 
     test "should ignore unknown player as worst player" do
       game = create_game

--- a/test/models/concerns/players/game_stats_test.rb
+++ b/test/models/concerns/players/game_stats_test.rb
@@ -86,11 +86,38 @@ class GameStatsTest < ActiveSupport::TestCase
         game = create_game
         create_session(game, losing_players: [player])
 
-        worst_game = player.worst_game
+        worst_games = player.worst_games
 
+        assert_equal 1, worst_games.count
+        worst_game = worst_games.first
         assert_equal game, worst_game.game
         assert_equal 0, worst_game.win_percent
     end
+
+    test "should return top 3 games for worst game" do
+        player = create_player
+        game1 = create_game
+        game2 = create_game('game2')
+        game3 = create_game('game3')
+        create_session(game1, losing_players: [player])
+        create_session(game2, losing_players: [player])
+        create_session(game2, winning_players: [player])
+        create_session(game3, winning_players: [player])
+
+        worst_games = player.worst_games
+
+        assert_equal 3, worst_games.count
+        worst_game = worst_games.first
+        assert_equal game1, worst_game.game
+        assert_equal 0, worst_game.win_percent
+        second_worst = worst_games[1]
+        assert_equal game2, second_worst.game
+        assert_equal 0.5, second_worst.win_percent
+        third_worst = worst_games[2]
+        assert_equal game3, third_worst.game
+        assert_equal 1, third_worst.win_percent
+    end
+
 
     test "should calculate win % correctly for worst game" do
         player = create_player
@@ -98,8 +125,10 @@ class GameStatsTest < ActiveSupport::TestCase
         3.times { create_session(game, losing_players: [player]) }
         create_session(game, winning_players: [player])
 
-        worst_game = player.worst_game
+        worst_games = player.worst_games
 
+        assert_equal 1, worst_games.count
+        worst_game = worst_games.first
         assert_equal game, worst_game.game
         assert_equal 0.25, worst_game.win_percent
     end
@@ -111,8 +140,9 @@ class GameStatsTest < ActiveSupport::TestCase
         create_session(game_one, losing_players: [player])
         create_session(game_two, losing_players: [player])
 
-        worst_game = player.worst_game
+        worst_games = player.worst_games
 
+        worst_game = worst_games.first
         assert_includes [game_one, game_two], worst_game.game
         assert_equal 0, worst_game.win_percent
     end
@@ -122,8 +152,10 @@ class GameStatsTest < ActiveSupport::TestCase
         game = create_game
         create_session(game, winning_players: [player], losing_players: [player])
 
-        worst_game = player.worst_game
+        worst_games = player.worst_games
 
+        assert_equal 1, worst_games.count
+        worst_game = worst_games.first
         assert_equal game, worst_game.game
         assert_equal 0, worst_game.win_percent
     end

--- a/test/models/concerns/players/game_stats_test.rb
+++ b/test/models/concerns/players/game_stats_test.rb
@@ -14,30 +14,34 @@ class GameStatsTest < ActiveSupport::TestCase
         best_game = best_games.first
         assert_equal game, best_game.game
         assert_equal 1, best_game.win_percent
+        assert_equal 1, best_game.play_count
     end
 
     test "should return top 3 games for best game" do
         player = create_player
-        game1 = create_game
-        game2 = create_game('game2')
-        game3 = create_game('game3')
-        create_session(game1, winning_players: [player])
-        create_session(game2, winning_players: [player])
-        create_session(game2, losing_players: [player])
-        create_session(game3, losing_players: [player])
+        game_one = create_game
+        game_two = create_game('game_two')
+        game_three = create_game('game_three')
+        create_session(game_one, winning_players: [player])
+        create_session(game_two, winning_players: [player])
+        create_session(game_two, losing_players: [player])
+        create_session(game_three, losing_players: [player])
 
         best_games = player.best_games
 
         assert_equal 3, best_games.count
         best_game = best_games.first
-        assert_equal game1, best_game.game
+        assert_equal game_one, best_game.game
         assert_equal 1, best_game.win_percent
+        assert_equal 1, best_game.play_count
         second_best = best_games[1]
-        assert_equal game2, second_best.game
+        assert_equal game_two, second_best.game
         assert_equal 0.5, second_best.win_percent
+        assert_equal 2, second_best.play_count
         third_best = best_games[2]
-        assert_equal game3, third_best.game
+        assert_equal game_three, third_best.game
         assert_equal 0, third_best.win_percent
+        assert_equal 1, third_best.play_count
     end
 
     test "should calculate win % correctly for best game" do
@@ -52,12 +56,13 @@ class GameStatsTest < ActiveSupport::TestCase
         best_game = best_games.first
         assert_equal game, best_game.game
         assert_equal 0.75, best_game.win_percent
+        assert_equal 4, best_game.play_count
     end
 
     test "should choose an arbitrary game when tied for best game" do
         player = create_player
         game_one = create_game
-        game_two = create_game ('other')
+        game_two = create_game('other')
         create_session(game_one, winning_players: [player])
         create_session(game_two, winning_players: [player])
 
@@ -66,6 +71,24 @@ class GameStatsTest < ActiveSupport::TestCase
         best_game = best_games.first
         assert_includes [game_one, game_two], best_game.game
         assert_equal 1, best_game.win_percent
+        assert_equal 1, best_game.play_count
+    end
+
+    test "should choose most played game when tied for best game" do
+        player = create_player
+        game_one = create_game
+        game_two = create_game('other')
+        create_session(game_one, winning_players: [player])
+        create_session(game_two, winning_players: [player])
+        create_session(game_two, winning_players: [player])
+
+        best_games = player.best_games
+
+        best_game = best_games.first
+        assert_equal game_two, best_game.game
+        assert_equal 1, best_game.win_percent
+        assert_equal 2, best_game.play_count
+
     end
 
     test "should choose best placing in game when playing as multiple players for best game" do
@@ -79,6 +102,7 @@ class GameStatsTest < ActiveSupport::TestCase
         best_game = best_games.first
         assert_equal game, best_game.game
         assert_equal 1, best_game.win_percent
+        assert_equal 1, best_game.play_count
     end
 
     test "should return a game as worst game" do
@@ -96,25 +120,25 @@ class GameStatsTest < ActiveSupport::TestCase
 
     test "should return top 3 games for worst game" do
         player = create_player
-        game1 = create_game
-        game2 = create_game('game2')
-        game3 = create_game('game3')
-        create_session(game1, losing_players: [player])
-        create_session(game2, losing_players: [player])
-        create_session(game2, winning_players: [player])
-        create_session(game3, winning_players: [player])
+        game_one = create_game
+        game_two = create_game('game_two')
+        game_three = create_game('game_three')
+        create_session(game_one, losing_players: [player])
+        create_session(game_two, losing_players: [player])
+        create_session(game_two, winning_players: [player])
+        create_session(game_three, winning_players: [player])
 
         worst_games = player.worst_games
 
         assert_equal 3, worst_games.count
         worst_game = worst_games.first
-        assert_equal game1, worst_game.game
+        assert_equal game_one, worst_game.game
         assert_equal 0, worst_game.win_percent
         second_worst = worst_games[1]
-        assert_equal game2, second_worst.game
+        assert_equal game_two, second_worst.game
         assert_equal 0.5, second_worst.win_percent
         third_worst = worst_games[2]
-        assert_equal game3, third_worst.game
+        assert_equal game_three, third_worst.game
         assert_equal 1, third_worst.win_percent
     end
 
@@ -136,7 +160,7 @@ class GameStatsTest < ActiveSupport::TestCase
     test "should choose an arbitrary game when tied for worst game" do
         player = create_player
         game_one = create_game
-        game_two = create_game ('other')
+        game_two = create_game('other')
         create_session(game_one, losing_players: [player])
         create_session(game_two, losing_players: [player])
 
@@ -201,10 +225,10 @@ class GameStatsTest < ActiveSupport::TestCase
 
     test "should calculate all sessions for win rate" do
         player = create_player
-        game1 = create_game
-        game2 = create_game('game2')
-        create_session(game1, losing_players: [player])
-        create_session(game2, winning_players: [player])
+        game_one = create_game
+        game_two = create_game('game_two')
+        create_session(game_one, losing_players: [player])
+        create_session(game_two, winning_players: [player])
 
         win_rate = player.win_rate
 

--- a/test/models/concerns/players/game_stats_test.rb
+++ b/test/models/concerns/players/game_stats_test.rb
@@ -8,10 +8,36 @@ class GameStatsTest < ActiveSupport::TestCase
         game = create_game
         create_session(game, winning_players: [player])
 
-        best_game = player.best_game
+        best_games = player.best_games
 
+        assert_equal 1, best_games.count
+        best_game = best_games.first
         assert_equal game, best_game.game
         assert_equal 1, best_game.win_percent
+    end
+
+    test "should return top 3 games for best game" do
+        player = create_player
+        game1 = create_game
+        game2 = create_game('game2')
+        game3 = create_game('game3')
+        create_session(game1, winning_players: [player])
+        create_session(game2, winning_players: [player])
+        create_session(game2, losing_players: [player])
+        create_session(game3, losing_players: [player])
+
+        best_games = player.best_games
+
+        assert_equal 3, best_games.count
+        best_game = best_games.first
+        assert_equal game1, best_game.game
+        assert_equal 1, best_game.win_percent
+        second_best = best_games[1]
+        assert_equal game2, second_best.game
+        assert_equal 0.5, second_best.win_percent
+        third_best = best_games[2]
+        assert_equal game3, third_best.game
+        assert_equal 0, third_best.win_percent
     end
 
     test "should calculate win % correctly for best game" do
@@ -20,8 +46,10 @@ class GameStatsTest < ActiveSupport::TestCase
         3.times { create_session(game, winning_players: [player]) }
         create_session(game, losing_players: [player])
 
-        best_game = player.best_game
+        best_games = player.best_games
 
+        assert_equal 1, best_games.count
+        best_game = best_games.first
         assert_equal game, best_game.game
         assert_equal 0.75, best_game.win_percent
     end
@@ -33,8 +61,9 @@ class GameStatsTest < ActiveSupport::TestCase
         create_session(game_one, winning_players: [player])
         create_session(game_two, winning_players: [player])
 
-        best_game = player.best_game
+        best_games = player.best_games
 
+        best_game = best_games.first
         assert_includes [game_one, game_two], best_game.game
         assert_equal 1, best_game.win_percent
     end
@@ -44,8 +73,10 @@ class GameStatsTest < ActiveSupport::TestCase
         game = create_game
         create_session(game, winning_players: [player], losing_players: [player])
 
-        best_game = player.best_game
+        best_games = player.best_games
 
+        assert_equal 1, best_games.count
+        best_game = best_games.first
         assert_equal game, best_game.game
         assert_equal 1, best_game.win_percent
     end

--- a/test/models/concerns/players/game_stats_test.rb
+++ b/test/models/concerns/players/game_stats_test.rb
@@ -88,7 +88,6 @@ class GameStatsTest < ActiveSupport::TestCase
         assert_equal game_two, best_game.game
         assert_equal 1, best_game.win_percent
         assert_equal 2, best_game.play_count
-
     end
 
     test "should choose best placing in game when playing as multiple players for best game" do
@@ -116,6 +115,7 @@ class GameStatsTest < ActiveSupport::TestCase
         worst_game = worst_games.first
         assert_equal game, worst_game.game
         assert_equal 0, worst_game.win_percent
+        assert_equal 1, worst_game.play_count
     end
 
     test "should return top 3 games for worst game" do
@@ -134,12 +134,15 @@ class GameStatsTest < ActiveSupport::TestCase
         worst_game = worst_games.first
         assert_equal game_one, worst_game.game
         assert_equal 0, worst_game.win_percent
+        assert_equal 1, worst_game.play_count
         second_worst = worst_games[1]
         assert_equal game_two, second_worst.game
         assert_equal 0.5, second_worst.win_percent
+        assert_equal 2, second_worst.play_count
         third_worst = worst_games[2]
         assert_equal game_three, third_worst.game
         assert_equal 1, third_worst.win_percent
+        assert_equal 1, third_worst.play_count
     end
 
 
@@ -155,6 +158,7 @@ class GameStatsTest < ActiveSupport::TestCase
         worst_game = worst_games.first
         assert_equal game, worst_game.game
         assert_equal 0.25, worst_game.win_percent
+        assert_equal 4, worst_game.play_count
     end
 
     test "should choose an arbitrary game when tied for worst game" do
@@ -169,6 +173,24 @@ class GameStatsTest < ActiveSupport::TestCase
         worst_game = worst_games.first
         assert_includes [game_one, game_two], worst_game.game
         assert_equal 0, worst_game.win_percent
+        assert_equal 1, worst_game.play_count
+    end
+
+    test "should choose most played game when tied for worst game" do
+        player = create_player
+        game_one = create_game
+        game_two = create_game('other')
+        create_session(game_one, losing_players: [player])
+        create_session(game_two, losing_players: [player])
+        create_session(game_two, losing_players: [player])
+
+        worst_games = player.worst_games
+
+        worst_game = worst_games.first
+        assert_equal game_two, worst_game.game
+        assert_equal 0, worst_game.win_percent
+        assert_equal 2, worst_game.play_count
+
     end
 
     test "should choose worst placing in game when playing as multiple players for worst game" do
@@ -182,6 +204,7 @@ class GameStatsTest < ActiveSupport::TestCase
         worst_game = worst_games.first
         assert_equal game, worst_game.game
         assert_equal 0, worst_game.win_percent
+        assert_equal 1, worst_game.play_count
     end
 
     test "should return 0 for win rate when no games have been played" do


### PR DESCRIPTION
On players page
* Display top 3 best and worst games (increased from 1)
* Display the play count for each of these

On games page
* Display top 3 best players
* Remove worst players - eases implementation of above and is somewhat negative
* Display the play count for each best player

With new play count, break ties in case where both have same win percentage (favoring more plays).