### PR TITLE
Validate New Sessions To Prevent Bad Data

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,5 +1,6 @@
 class Session < ApplicationRecord
   belongs_to :game
+  validates :played, presence: true
   validates_associated :game
 
   has_many :session_players, inverse_of: :session

--- a/app/models/session_player.rb
+++ b/app/models/session_player.rb
@@ -1,4 +1,5 @@
 class SessionPlayer < ApplicationRecord
   belongs_to :player
   belongs_to :session
+  validates :placing, presence: true
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -43,6 +43,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     session_params = {
       session: { 
           game_id: @session.game_id,
+          played: Date.new,
           session_players_attributes: [
             { player_id: player_one.id, score: 5, placing: 1}
           ] 

--- a/test/models/session_test.rb
+++ b/test/models/session_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class SessionTest < ActiveSupport::TestCase
   test "should succeed when session is valid" do
     game = games(:one)
-    session = Session.new(game: game)
+    session = Session.new(game: game, played: Date.new)
     player = session_players(:one)
     session.session_players << player
 


### PR DESCRIPTION
Validate all new session for required properties.

Missing validations:
* Session's **Played** date
* Session Players' **Placing**

_Note_ Session Player's **Score** can be empty on games without score.