### PR TITLE
Only Add Blank Session Player When None Exist

### DIFF
--- a/app/views/sessions/_form.html.erb
+++ b/app/views/sessions/_form.html.erb
@@ -66,5 +66,9 @@
 
 <script>
   //Add a player by default
-  $(document).ready(function() { $(".add_fields").click() } );
+  $(document).ready(function() { 
+    if (<%= @session.session_players.empty? %>) {
+      $(".add_fields").click() 
+    }
+  });
 </script>


### PR DESCRIPTION
There is code on the new session form to create a blank player for the session. But this was blinding adding a new one, causing the table to expand incorrectly in cases like reloading the page on validation failure. The logic was changed to only add a blank row when the table is blank.