### PR TITLE
Allow Decimal Scores For Sessions

### DIFF
--- a/app/views/sessions/_session_player_fields.html.erb
+++ b/app/views/sessions/_session_player_fields.html.erb
@@ -1,6 +1,6 @@
 <tr class='nested-fields'>
     <td class='field'><%= f.collection_select :player_id, Player.order(:name), :id, :name, include_blank: true %></td> 
-    <td class='field'><%= f.number_field :score %></td>
+    <td class='field'><%= f.number_field :score, :step => 0.01 %></td>
     <td class='field'><%= f.number_field :placing %></td>
     <td class='field'><%= f.text_field :team %></td>
     <td>


### PR DESCRIPTION
There are games where a score can be a decimal value (eg Dungeon Lords). Allow up to 2 decimal places for these, as well as for distinguishing tie-breakers for non-score tie-breakers.