### PR TITLE
Add 2 New Player Stats

### DIFF
--- a/app/models/concerns/players/game_stats.rb
+++ b/app/models/concerns/players/game_stats.rb
@@ -2,6 +2,16 @@ module Players
     module GameStats
         extend ActiveSupport::Concern
         RESULT_COUNT = 3
+
+        def session_count
+            query_result = SessionPlayer
+                .where('player_id = ?', id)
+                .pluck('DISTINCT session_id')
+                .count()
+                
+            query_result.blank? ? 0 : query_result
+        end
+    
         
         def best_games
             subquery = SessionPlayer.joins(:session)

--- a/app/models/concerns/players/game_stats.rb
+++ b/app/models/concerns/players/game_stats.rb
@@ -55,6 +55,22 @@ module Players
             return query_result.to_a[0]['win_percent'] ||= 0
         end
 
+        def competitive_win_rate
+            subquery = SessionPlayer.joins(:session)
+                            .group('sessions.id')
+                            .where('player_id = ?', id)
+                            .where("sessions.game_id in 
+                                (SELECT id from games g where g.game_type <> 'cooperative')")
+                            .select('CASE MIN("placing") WHEN 1 THEN 1 ELSE 0 END as didWin ')
+    
+            query_result = SessionPlayer
+                .from(subquery)
+                .select('sum(subquery.didWin) / count(*)::float as win_percent')
+    
+            return 0 if query_result.blank?
+            return query_result.to_a[0]['win_percent'] ||= 0
+        end
+
         private
             def to_percent (game_total)
                 return nil unless game_total

--- a/app/views/players/show.html.erb
+++ b/app/views/players/show.html.erb
@@ -6,6 +6,14 @@
 <div class="container">
   <div class="row">
     <div class="col-md font-weight-bold">
+      Total Session Count
+    </div>
+    <div class="col-md">
+      <td><%= @player.session_count %></td>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md font-weight-bold">
       Overall Win Rate
     </div>
     <div class="col-md">

--- a/app/views/players/show.html.erb
+++ b/app/views/players/show.html.erb
@@ -13,6 +13,15 @@
     </div>
   </div>
 
+  <div class="row">
+    <div class="col-md font-weight-bold">
+      Competitive Win Rate
+    </div>
+    <div class="col-md">
+      <td><%= number_with_precision((@player.competitive_win_rate * 100), precision: 2, strip_insignificant_zeros: true) %></td>%
+    </div>
+  </div>
+
 <% unless @player.best_games.nil? %>
 
   <div class="row">


### PR DESCRIPTION
Add 2 new stats to the player page:
* **Session Count** - returns the overall number of sessions played. Only counts once if playing multiple characters in a session.
* **Competitive Win Rate** - returns the win rate for non-cooperative games.

For 2️⃣ , there is no need to also include a cooperative win rate as that is not an interesting metric.